### PR TITLE
Support #![no_std]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use proc_macro_hack::proc_macro_hack;
 
 #[proc_macro_hack]


### PR DESCRIPTION
Nothing in this crate needs the standard library, so don't compile one in.