### PR TITLE
update syn and quote dependencies to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arr_macro"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Josh Mcguigan"]
 edition = "2018"
 description = "Initialize arrays with ease!"
@@ -10,7 +10,7 @@ keywords = ["array", "macro", "initialization", "init"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-arr_macro_impl = { version = "0.1.2", path = "impl" }
+arr_macro_impl = { version = "0.1.3", path = "impl" }
 proc-macro-hack = "0.5"
 
 [workspace]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arr_macro_impl"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Josh Mcguigan"]
 edition = "2018"
 description = "Private impl crate for arr_macro"
@@ -12,9 +12,9 @@ proc-macro = true
 
 [dependencies]
 proc-macro-hack = "0.5"
-quote = "0.6.10"
+quote = "1.0"
 
 [dependencies.syn]
-version = "0.15.23"
+version = "1.0"
 default-features = true
 features = ["full"]

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -37,7 +37,11 @@ pub fn arr(input: TokenStream) -> TokenStream {
         quantity
     } = parse_macro_input!(input as ArrayInit);
 
-    let iter = std::iter::repeat(value).take(quantity.value() as usize);
+    let iter = std::iter::repeat(value).take(
+        quantity
+            .base10_parse::<usize>()
+            .expect("Failed to parse LitInt as usize"),
+    );
 
     let result = quote! {
         [#(#iter),*]


### PR DESCRIPTION
Fixes #5 

The syn crate deprecated LitInt::value() at some point, but as best as I can tell the code below is equivalent, at least up to max usize. 